### PR TITLE
add greenkeeper.io link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,7 @@
 - [npm-top](https://gist.github.com/bcoe/dcc961b869bbf6685002) - npm users by downloads.
 - [npm semver calculator](http://semver.npmjs.com) - Visually explore what versions of a package a semver range matches.
 - [npm-stats](http://www.npm-stats.com) - Displays metrics about packages.
+- [greenkeeper.io](http://greenkeeper.io/) - Automatically create pull requests when npm package dependencies are updated.
 
 ### Browser extensions
 


### PR DESCRIPTION
I've been enabling greenkeeper.io on many of my projects, and am a huge fan. I find the automated pull requests keep me much more diligent but updating my dependencies.
