### PR TITLE
add ghub.io

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -50,6 +50,7 @@
 - [npm semver calculator](http://semver.npmjs.com) - Visually explore what versions of a package a semver range matches.
 - [npm-stats](http://www.npm-stats.com) - Displays metrics about packages.
 - [greenkeeper.io](http://greenkeeper.io) - Automates dependency updates through pull requests.
+- [ghub.io](http://ghub.io) - Redirect to an npm package's GitHub page, if available.
 
 ### Browser extensions
 


### PR DESCRIPTION
A little service from @juliangruber that redirects to the given npm package's github repo.

Example: http://ghub.io/ava

http://ghub.io
