### PR TITLE
Add pkgd to Packages/Publishing list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -67,6 +67,7 @@
 - [npm-release](https://github.com/phuu/npm-release) - Making releasing to npm so easy a kitten could probably do it™.
 - [pkgfiles](https://github.com/timoxley/pkgfiles) - List all files which would be published in a package.
 - [semantic-release](https://github.com/semantic-release/semantic-release) - Fully automated package publishing.
+- [pkgd](https://github.com/inikulin/pkgd) - Get package publish info: package.json and file list.
 
 ### Registry
 


### PR DESCRIPTION
There are some packages in npm already that read package files. However, some of them are broken and the others are too slow. Moreover, this package reads package.json as well and provides nice Promise-based interface.
