### PR TITLE
Add npm-cli-login

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,7 @@
 - [npm-user-packages](https://github.com/kevva/npm-user-packages-cli) - Get packages by an npm user.
 - [dpn](https://github.com/gillstrom/dpn) - Get the dependents of a user's npm packages.
 - [npm-stats](https://github.com/hughsk/npm-stats) - Get data from an npm registry.
+- [npm-cli-login](https://github.com/postmanlabs/npm-cli-login) - Log in to NPM without STDIN, STDOUT.
 
 ### Other
 


### PR DESCRIPTION
[npm-cli-login](https://github.com/postmanlabs/npm-cli-login) allows you to programatically log into a registry.
Useful for testing(CI servers) and deployment, specially when using a private registry
