### PR TITLE
Add "Why npm scripts?" to the list of Articles

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,7 @@
 - [Install npm packages globally without sudo on OS X and Linux](https://github.com/sindresorhus/guides/blob/master/npm-global-without-sudo.md)
 - [Optimizing the footprint of an npm package](https://medium.com/@goldglovecb/npm-needs-a-personal-trainer-537e0f8859c6)
 - [The Art of Node](https://github.com/maxogden/art-of-node#modules) - An introduction to Node.js and client-side development with npm.
+- [Why npm scripts?](https://css-tricks.com/why-npm-scripts/) - An introduction to npm scripts with common packages and scripts, as well as a boilerplate project.
 
 
 ## Tools


### PR DESCRIPTION
I [wrote an article for CSS-Tricks](https://css-tricks.com/why-npm-scripts/) that introduces npm scripts and had a set of common packages & scripts that I use often. I also created a [npm-build-boilerplate](https://github.com/damonbauer/npm-build-boilerplate) project to go along with the article.
