### PR TITLE
Fix link to package.json properties exposure

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -182,7 +182,7 @@ $ npm run cat
 Max
 ```
 
-All package.json properties are [exposed](https://docs.npmjs.com/misc/scripts#package-json-vars) as environment variables:
+All package.json properties are [exposed](https://docs.npmjs.com/misc/scripts#packagejson-vars) as environment variables:
 
 ```json
 {


### PR DESCRIPTION
Link to npm docs about package.json properties exposure had an errant hyphen.
