### PR TITLE
Update info about `pnpm`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -125,8 +125,8 @@ You might also like [awesome-nodejs](https://github.com/sindresorhus/awesome-nod
 
 - [yarn](https://github.com/yarnpkg/yarn) - Fast, reliable, and secure dependency management.
 - [npm](https://github.com/npm/npm) - The official client.
+- [pnpm](https://github.com/pnpm/pnpm) - Fast, disk space efficient npm installs.
 - [ied](https://github.com/alexanderGugel/ied) - Faster npm.
-- [pnpm](https://github.com/rstacruz/pnpm) - Performant `npm install`.
 
 
 ## Tips


### PR DESCRIPTION
pnpm is more popular currently than `ied`, so moved one position up.

Updated the URL to pnpm as it has been moved to an org.

Updated the description of pnpm with the up to date description