### PR TITLE
Update --save tip for npm 5

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -168,12 +168,12 @@ alias nlg='npm list --global --depth=0'
 ```
 
 
-### Add to package.json when installing
+### Don't add to package.json when installing
 
-You can have npm add packages to package.json when installing by specifying the `--save`/`-S` flag for `dependencies` and `--save-dev`/`-D` for `devDependencies`:
+By default npm adds any package you install to the `dependencies` field in package.json (since v5.0.0). You can prevent this by specifying the `--no-save` flag or you can add it to `devDependencies` with `-save-dev`/`-D`:
 
 ```
-$ npm install --save chalk
+$ npm install --save-dev mocha
 ```
 
 ### Run scripts

--- a/readme.md
+++ b/readme.md
@@ -170,10 +170,10 @@ alias nlg='npm list --global --depth=0'
 
 ### Don't add to package.json when installing
 
-By default npm adds any package you install to the `dependencies` field in package.json (since v5.0.0). You can prevent this by specifying the `--no-save` flag or you can add it to `devDependencies` with `-save-dev`/`-D`:
+By default npm adds any package you install to the `dependencies` field in package.json (since v5). You can prevent this by specifying the `--no-save` flag or you can add it to `devDependencies` with `--save-dev`/`-D`:
 
 ```
-$ npm install --save-dev mocha
+$ npm install --save-dev ava
 ```
 
 ### Run scripts

--- a/readme.md
+++ b/readme.md
@@ -170,7 +170,7 @@ alias nlg='npm list --global --depth=0'
 
 ### Don't add to package.json when installing
 
-By default npm adds any package you install to the `dependencies` field in package.json (since v5). You can prevent this by specifying the `--no-save` flag or you can add it to `devDependencies` with `--save-dev`/`-D`:
+By default npm adds packages you install to the `dependencies` field in package.json (since v5). You can prevent this by specifying the `--no-save` flag. You can add a package to `devDependencies` with `--save-dev`/`-D`:
 
 ```
 $ npm install --save-dev ava


### PR DESCRIPTION
In npm v5 the `--save` flag is not needed anymore. Instead, you need `--no-save` if you don't want the package in your deps.