### PR TITLE
Add tip about installing Git dependencies with semver

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -281,6 +281,11 @@ $ npm install 'sindresorhus/chalk#51b8f32'
 
 Specify either a commit SHA, branch, tag, or nothing.
 
+With npm v5.0.0 or newer, you can install git dependencies with semver.
+
+```
+$ npm install sindresorhus/chalk#semver:^2.0.0
+```
 
 ### Install a specific version of a package
 

--- a/readme.md
+++ b/readme.md
@@ -281,10 +281,10 @@ $ npm install 'sindresorhus/chalk#51b8f32'
 
 Specify either a commit SHA, branch, tag, or nothing.
 
-With npm v5.0.0 or newer, you can install git dependencies with semver.
+You can also install Git dependencies with semver: *(Requires npm v5 or newer)*
 
 ```
-$ npm install sindresorhus/chalk#semver:^2.0.0
+$ npm install 'sindresorhus/chalk#semver:^2.0.0'
 ```
 
 ### Install a specific version of a package


### PR DESCRIPTION
With npm 5, semver support was [added for git dependencies](http://blog.npmjs.org/post/161081169345/v500). This can be particularly useful for private repositories since it allows you to use semver for projects that can't be published to npm.