### PR TITLE
Add cloudsmith

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -95,6 +95,7 @@ You might also like [awesome-nodejs](https://github.com/sindresorhus/awesome-nod
 - [nrm](https://github.com/Pana/nrm) - Registry manager.
 - [npm-register](https://github.com/dickeyxxx/npm-register) - Easy to set up and maintain npm registry and proxy.
 - [verdaccio](https://github.com/verdaccio/verdaccio) - Lightweight private npm proxy registry.
+- [cloudsmith](https://cloudsmith.io) - A fully managed package management SaaS with support for npm registries (and many others).
 
 ### Other
 

--- a/readme.md
+++ b/readme.md
@@ -95,7 +95,7 @@ You might also like [awesome-nodejs](https://github.com/sindresorhus/awesome-nod
 - [nrm](https://github.com/Pana/nrm) - Registry manager.
 - [npm-register](https://github.com/dickeyxxx/npm-register) - Easy to set up and maintain npm registry and proxy.
 - [verdaccio](https://github.com/verdaccio/verdaccio) - Lightweight private npm proxy registry.
-- [cloudsmith](https://cloudsmith.io) - A fully managed package management SaaS with support for npm registries (and many others).
+- [cloudsmith](https://cloudsmith.io/f/open_source/) - A fully managed package management SaaS with support for npm registries (and many others).
 
 ### Other
 


### PR DESCRIPTION
Hi! This PR adds a link to [Cloudsmith](https://cloudsmith.io), which is a package management service SaaS. It's commercial, but it is completely free for open-source and it has generous free tiers otherwise. It has first-class support for npm registries (and many other package formats, such as Python/Ruby), plus org/teams management, granular access controls, private repositories, repository-specific entitlements, a worldwide content distribution network, webhooks, access logs, etc. Thank you. :-)