### PR TITLE
Add my-npm-stats

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,7 @@
 - [npm-top](https://gist.github.com/bcoe/dcc961b869bbf6685002) - npm users by downloads.
 - [npm semver calculator](http://semver.npmjs.com) - Visually explore what versions of a package a semver range matches.
 - [npm-stats](http://www.npm-stats.com) - Displays metrics about packages.
+- [my-npm-stats](https://my-npm-stats.org) - Package stats and dependents for NPM authors.
 - [ghub.io](https://ghub.io) - Redirects to the GitHub repo of an npm package.
 - [npm addict](https://npmaddict.com) - Your daily injection of npm packages.
 


### PR DESCRIPTION
Hey, I recently built a stats tool for NPM that shows the weekly downloads as of npmjs.org and also the number of dependents (which is an indicator for the popularity of the package). So it might fit in the list of already-existing npm stat tools.

https://my-npm-stats.org/