### PR TITLE
Add oss-maintenance-log to Other section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -123,6 +123,7 @@
 - [luna](https://github.com/rvpanoz/luna) - App to manage npm dependencies.
 - [emma-cli](https://github.com/maticzav/emma-cli) - Interactive CLI package search utility.
 - [lockfile-lint](https://github.com/lirantal/lockfile-lint) - Lint lockfiles for improved security and trust policies to mitigate malicious package injection and insecure lockfile resources.
+- [oss-maintenance-log](https://github.com/dusan-maintains/oss-maintenance-log) - Automated public evidence log for OSS maintenance. Tracks PR SLA, npm health, and repo metrics across abandoned packages. Self-updates every 6h.
 
 ## Clients
 


### PR DESCRIPTION
Adds [oss-maintenance-log](https://github.com/dusan-maintains/oss-maintenance-log) — an automated public evidence log for OSS maintenance work.

It tracks PR SLA, npm download health, and repo metrics across abandoned-but-critical packages, committing machine-readable JSON + Markdown snapshots every 6 hours via GitHub Actions. Zero manual updates.

Currently tracking packages with a combined **1.7M npm downloads/week** including `rrule`, `python-shell`, `jquery-modal`, and others.

- MIT licensed
- Reusable as a template repo
- Live dashboard: https://dusan-maintains.github.io/oss-maintenance-log